### PR TITLE
Add the popover component and use in many places

### DIFF
--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -63,6 +63,10 @@ const Popover: React.FC<PopoverProps> = ({
     return () => window.removeEventListener("click", onclick);
   });
 
+  useEffect(() => {
+    setPoint(calculatePoint());
+  }, [rect.clientLeft, rect.clientTop, rect.clientWidth, rect.clientHeight]);
+
   function shouldShowWhen(action: TriggerAction) {
     if (visible !== undefined) return false;
     if (typeof triggerAction === "string" && triggerAction === action) return true;

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -183,7 +183,8 @@ const Popover: React.FC<PopoverProps> = ({
         y={point.pageY}
         width={full ? clientWidth : undefined}
         onMouseEnter={() => setPopupVisible(true)}
-        onMouseLeave={() => triggerAction === "hover" && setPopupVisible(false)}
+        onMouseLeave={() => shouldShowWhen("hover") && setPopupVisible(false)}
+        onClick={(e) => shouldShowWhen("click") && e.stopPropagation()}
       >
         {content}
       </Popup>

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import classNames from "classnames";
 import styled from "styled-components";
-import { useMeasure } from "../hooks";
+import { useMeasure, UseMeasureRef } from "../hooks";
 import { tuple } from "../utils/type";
 import Portal from "./Portal";
 
@@ -14,6 +14,11 @@ export type Placement = typeof Placements[number];
 type Point = {
   pageX: number;
   pageY: number;
+};
+
+type ExtendedProps = React.HTMLAttributes<HTMLElement> & {
+  key: string;
+  ref: UseMeasureRef;
 };
 
 type TriggerEvent = React.FocusEvent<HTMLHRElement> | React.MouseEvent<HTMLHRElement>;
@@ -35,6 +40,21 @@ const Popup = styled.div<{ x: number; y: number; width?: number }>`
   z-index: 999;
 `;
 
+function getContainer(): HTMLDivElement {
+  const container = document.createElement("div");
+  container.style.position = "absolute";
+  container.style.left = "0";
+  container.style.top = "0";
+  container.style.width = "100%";
+  attachParent(container);
+  return container;
+}
+
+function attachParent(container: HTMLDivElement): void {
+  const mountNode = document.body;
+  mountNode.appendChild(container);
+}
+
 const Popover: React.FC<PopoverProps> = ({
   content,
   children,
@@ -44,7 +64,7 @@ const Popover: React.FC<PopoverProps> = ({
   triggerAction = "hover",
   full = false,
 }) => {
-  const { ref, rect } = useMeasure();
+  const [ref, rect] = useMeasure();
   const [point, setPoint] = useState<Point>({ pageX: 0, pageY: 0 });
   const [popupVisible, setPopupVisible] = useState<boolean>(false);
 
@@ -67,23 +87,24 @@ const Popover: React.FC<PopoverProps> = ({
     setPoint(calculatePoint());
   }, [rect.clientLeft, rect.clientTop, rect.clientWidth, rect.clientHeight]);
 
-  function shouldShowWhen(action: TriggerAction) {
+  function shouldShowWhen(action: TriggerAction): boolean {
     if (visible !== undefined) return false;
     if (typeof triggerAction === "string" && triggerAction === action) return true;
+    return false;
   }
 
-  function fireEvents(type: string, event: TriggerEvent) {
+  function fireEvents(type: string, event: TriggerEvent): void {
     const childCallback = (children as React.ReactElement).props[type];
     childCallback && childCallback(event);
   }
 
-  function onPopupVisible(visible: boolean) {
+  function onPopupVisible(visible: boolean): void {
     if (visible === popupVisible) return;
     setPopupVisible(visible);
     setPoint(calculatePoint());
   }
 
-  function calculatePoint() {
+  function calculatePoint(): Point {
     const { clientLeft, clientTop, clientHeight, clientWidth } = rect;
     let pageX = 0;
     let pageY = 0;
@@ -100,34 +121,34 @@ const Popover: React.FC<PopoverProps> = ({
     return { pageX, pageY };
   }
 
-  function onFocus(event: React.FocusEvent<HTMLHRElement>) {
+  function onFocus(event: React.FocusEvent<HTMLHRElement>): void {
     fireEvents("onFocus", event);
     onPopupVisible(true);
   }
 
-  function onBlur(event: React.FocusEvent<HTMLHRElement>) {
+  function onBlur(event: React.FocusEvent<HTMLHRElement>): void {
     fireEvents("onBlur", event);
     onPopupVisible(false);
   }
 
-  function onMouseEnter(event: React.MouseEvent<HTMLHRElement>) {
+  function onMouseEnter(event: React.MouseEvent<HTMLHRElement>): void {
     fireEvents("onMouseEnter", event);
     onPopupVisible(true);
   }
 
-  function onMouseLeave(event: React.MouseEvent<HTMLHRElement>) {
+  function onMouseLeave(event: React.MouseEvent<HTMLHRElement>): void {
     fireEvents("onMouseLeave", event);
     onPopupVisible(false);
   }
 
-  function onClick(event: React.MouseEvent<HTMLHRElement>) {
+  function onClick(event: React.MouseEvent<HTMLHRElement>): void {
     event.stopPropagation();
     fireEvents("onClick", event);
     onPopupVisible(!popupVisible);
   }
 
-  function getNewChildProps() {
-    const props: React.HTMLAttributes<HTMLElement> & { key: string; ref: typeof ref } = {
+  function getNewChildProps(): ExtendedProps {
+    const props: ExtendedProps = {
       key: "trigger",
       ref,
     };
@@ -149,7 +170,7 @@ const Popover: React.FC<PopoverProps> = ({
     return props;
   }
 
-  function getContent() {
+  function getContent(): React.ReactNode {
     const classes = classNames(className, "bg-white shadow p-2", {
       "transform -translate-y-full": placement === "top",
       "transform -translate-x-full": placement === "left",
@@ -167,21 +188,6 @@ const Popover: React.FC<PopoverProps> = ({
         {content}
       </Popup>
     );
-  }
-
-  function getContainer() {
-    const container = document.createElement("div");
-    container.style.position = "absolute";
-    container.style.left = "0";
-    container.style.top = "0";
-    container.style.width = "100%";
-    attachParent(container);
-    return container;
-  }
-
-  function attachParent(container: HTMLDivElement) {
-    const mountNode = document.body;
-    mountNode.appendChild(container);
   }
 
   return (

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -1,0 +1,191 @@
+import React, { useEffect, useState } from "react";
+import classNames from "classnames";
+import styled from "styled-components";
+import { useMeasure } from "../hooks";
+import { tuple } from "../utils/type";
+import Portal from "./Portal";
+
+const TriggerActions = tuple("hover", "click", "focus");
+export type TriggerAction = typeof TriggerActions[number];
+
+const Placements = tuple("top", "left", "right", "bottom");
+export type Placement = typeof Placements[number];
+
+type Point = {
+  pageX: number;
+  pageY: number;
+};
+
+type TriggerEvent = React.FocusEvent<HTMLHRElement> | React.MouseEvent<HTMLHRElement>;
+
+export type PopoverProps = React.PropsWithChildren<{
+  content?: React.ReactNode;
+  visible?: boolean;
+  triggerAction?: TriggerAction;
+  placement?: Placement;
+  className?: String;
+  full?: boolean;
+}>;
+
+const Popup = styled.div<{ x: number; y: number; width?: number }>`
+  position: absolute;
+  left: ${(props) => props.x}px;
+  top: ${(props) => props.y}px;
+  width: ${(props) => props.width}px;
+  z-index: 999;
+`;
+
+const Popover: React.FC<PopoverProps> = ({
+  content,
+  children,
+  visible,
+  className,
+  placement = "bottom",
+  triggerAction = "hover",
+  full = false,
+}) => {
+  const { ref, rect } = useMeasure();
+  const [point, setPoint] = useState<Point>({ pageX: 0, pageY: 0 });
+  const [popupVisible, setPopupVisible] = useState<boolean>(false);
+
+  const newChildProps = getNewChildProps();
+  const child = React.Children.only(children) as React.ReactElement;
+  const trigger = React.cloneElement(child, newChildProps);
+  const showPopup = visible === undefined ? popupVisible : visible;
+  const portal = showPopup ? <Portal getContainer={getContainer}>{getContent()}</Portal> : null;
+
+  useEffect(() => {
+    const onclick = () => {
+      if (triggerAction !== "click") return;
+      if (popupVisible) setPopupVisible(false);
+    };
+    window.addEventListener("click", onclick);
+    return () => window.removeEventListener("click", onclick);
+  });
+
+  function shouldShowWhen(action: TriggerAction) {
+    if (visible !== undefined) return false;
+    if (typeof triggerAction === "string" && triggerAction === action) return true;
+  }
+
+  function fireEvents(type: string, event: TriggerEvent) {
+    const childCallback = (children as React.ReactElement).props[type];
+    childCallback && childCallback(event);
+  }
+
+  function onPopupVisible(visible: boolean) {
+    if (visible === popupVisible) return;
+    setPopupVisible(visible);
+    setPoint(calculatePoint());
+  }
+
+  function calculatePoint() {
+    const { clientLeft, clientTop, clientHeight, clientWidth } = rect;
+    let pageX = 0;
+    let pageY = 0;
+    if (placement === "bottom") {
+      pageX = clientLeft;
+      pageY = clientTop + clientHeight;
+    } else if (placement === "right") {
+      pageX = clientLeft + clientWidth;
+      pageY = clientTop;
+    } else {
+      pageX = clientLeft;
+      pageY = clientTop;
+    }
+    return { pageX, pageY };
+  }
+
+  function onFocus(event: React.FocusEvent<HTMLHRElement>) {
+    fireEvents("onFocus", event);
+    onPopupVisible(true);
+  }
+
+  function onBlur(event: React.FocusEvent<HTMLHRElement>) {
+    fireEvents("onBlur", event);
+    onPopupVisible(false);
+  }
+
+  function onMouseEnter(event: React.MouseEvent<HTMLHRElement>) {
+    fireEvents("onMouseEnter", event);
+    onPopupVisible(true);
+  }
+
+  function onMouseLeave(event: React.MouseEvent<HTMLHRElement>) {
+    fireEvents("onMouseLeave", event);
+    onPopupVisible(false);
+  }
+
+  function onClick(event: React.MouseEvent<HTMLHRElement>) {
+    event.stopPropagation();
+    fireEvents("onClick", event);
+    onPopupVisible(!popupVisible);
+  }
+
+  function getNewChildProps() {
+    const props: React.HTMLAttributes<HTMLElement> & { key: string; ref: typeof ref } = {
+      key: "trigger",
+      ref,
+    };
+
+    if (shouldShowWhen("focus")) {
+      props.onFocus = onFocus;
+      props.onBlur = onBlur;
+    }
+
+    if (shouldShowWhen("hover")) {
+      props.onMouseEnter = onMouseEnter;
+      props.onMouseLeave = onMouseLeave;
+    }
+
+    if (shouldShowWhen("click")) {
+      props.onClick = onClick;
+    }
+
+    return props;
+  }
+
+  function getContent() {
+    const classes = classNames(className, "bg-white shadow p-2", {
+      "transform -translate-y-full": placement === "top",
+      "transform -translate-x-full": placement === "left",
+    });
+    const { clientWidth } = rect;
+    return (
+      <Popup
+        className={classes}
+        x={point.pageX}
+        y={point.pageY}
+        width={full ? clientWidth : undefined}
+        onMouseEnter={() => setPopupVisible(true)}
+        onMouseLeave={() => triggerAction === "hover" && setPopupVisible(false)}
+      >
+        {content}
+      </Popup>
+    );
+  }
+
+  function getContainer() {
+    const container = document.createElement("div");
+    container.style.position = "absolute";
+    container.style.left = "0";
+    container.style.top = "0";
+    container.style.width = "100%";
+    attachParent(container);
+    return container;
+  }
+
+  function attachParent(container: HTMLDivElement) {
+    const mountNode = document.body;
+    mountNode.appendChild(container);
+  }
+
+  return (
+    <>
+      {trigger}
+      {portal}
+    </>
+  );
+};
+
+export default Popover;

--- a/src/components/Portal.tsx
+++ b/src/components/Portal.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useRef } from "react";
+import ReactDOM from "react-dom";
+
+export type PortalProps = {
+  getContainer: () => HTMLElement;
+};
+
+const Portal: React.FC<PortalProps> = ({ getContainer, children }) => {
+  const containerRef = useRef<HTMLElement>();
+  const initRef = useRef<boolean>(false);
+
+  if (!initRef.current) {
+    containerRef.current = getContainer();
+    initRef.current = true;
+  }
+
+  useEffect(() => {
+    return () => {
+      containerRef.current?.parentNode?.removeChild(containerRef.current);
+    };
+  }, []);
+
+  return containerRef.current ? ReactDOM.createPortal(children, containerRef.current) : null;
+};
+
+export default Portal;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useMeasure } from "./useMeasure";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as useMeasure } from "./useMeasure";
+export type { UseMeasureRect, UseMeasureRef } from "./useMeasure";

--- a/src/hooks/useMeasure.ts
+++ b/src/hooks/useMeasure.ts
@@ -1,7 +1,7 @@
-import { useMeasure } from "react-use";
-import React, { useState, useEffect, useRef } from "react";
+import { useMeasure as useContentMeasure } from "react-use";
+import { useState, useEffect, useRef } from "react";
 
-type ClientRect = {
+export type ClientRect = {
   clientLeft: number;
   clientRight: number;
   clientTop: number;
@@ -10,8 +10,17 @@ type ClientRect = {
   clientHeight: number;
 };
 
-export default function () {
-  const [ref, rect] = useMeasure();
+export type ContentRect = Pick<
+  DOMRectReadOnly,
+  "x" | "y" | "top" | "left" | "right" | "bottom" | "height" | "width"
+>;
+
+export type UseMeasureRect = ClientRect & ContentRect;
+
+export type UseMeasureRef = (element: Element) => void;
+
+export default function useMeasure(): [UseMeasureRef, UseMeasureRect] {
+  const [ref, rect] = useContentMeasure();
   const elementRef = useRef<Element>();
   const [clientRect, setClientRect] = useState<ClientRect>({
     clientBottom: 0,
@@ -43,5 +52,5 @@ export default function () {
     });
   }, [rect]);
 
-  return { ref: newRef, rect: { ...rect, ...clientRect } };
+  return [newRef, { ...rect, ...clientRect }];
 }

--- a/src/hooks/useMeasure.ts
+++ b/src/hooks/useMeasure.ts
@@ -1,0 +1,47 @@
+import { useMeasure } from "react-use";
+import React, { useState, useEffect, useRef } from "react";
+
+type ClientRect = {
+  clientLeft: number;
+  clientRight: number;
+  clientTop: number;
+  clientBottom: number;
+  clientWidth: number;
+  clientHeight: number;
+};
+
+export default function () {
+  const [ref, rect] = useMeasure();
+  const elementRef = useRef<Element>();
+  const [clientRect, setClientRect] = useState<ClientRect>({
+    clientBottom: 0,
+    clientRight: 0,
+    clientLeft: 0,
+    clientTop: 0,
+    clientWidth: 0,
+    clientHeight: 0,
+  });
+
+  const newRef = (element: Element) => {
+    if (!element) return;
+    elementRef.current = element;
+    ref(element);
+  };
+
+  useEffect(() => {
+    const element = elementRef.current;
+    if (!element) return;
+    const rect = element.getBoundingClientRect();
+
+    setClientRect({
+      clientLeft: rect.left,
+      clientRight: rect.right,
+      clientBottom: rect.bottom,
+      clientTop: rect.top,
+      clientWidth: rect.width,
+      clientHeight: rect.height,
+    });
+  }, [rect]);
+
+  return { ref: newRef, rect: { ...rect, ...clientRect } };
+}

--- a/src/pages/editor/panels/AssetsPanel.tsx
+++ b/src/pages/editor/panels/AssetsPanel.tsx
@@ -53,9 +53,8 @@ const AssetsPanel: React.FC<AssetsPanelProps> = (props) => {
     <Container className="w-full">
       <Popover triggerAction="click" content={<div>hello popover</div>} full>
         <Search className="p-2">
-          <Icon icon="search" />
           <input
-            className="bg-transparent ml-2 placeholder-gray-400 w-full"
+            className="bg-transparent placeholder-gray-400 w-full"
             placeholder="Search"
           ></input>
         </Search>

--- a/src/pages/editor/panels/AssetsPanel.tsx
+++ b/src/pages/editor/panels/AssetsPanel.tsx
@@ -7,6 +7,7 @@ import { TextNode, NodeType } from "../../../models/node";
 import Icon from "../../../components/Icon";
 import List from "../../../components/List";
 import AssetBlock from "../components/AssetBlock";
+import Popover from "../../../components/Popover";
 
 const { ListItem } = List;
 
@@ -16,8 +17,8 @@ const Search = styled.div`
   display: flex;
   align-items: center;
 
-  & > input:focus,
-  & > input {
+  & input:focus,
+  & input {
     border-width: 0;
     outline: none;
   }
@@ -50,13 +51,15 @@ const AssetsPanel: React.FC<AssetsPanelProps> = (props) => {
 
   return (
     <Container className="w-full">
-      <Search className="p-2">
-        <Icon icon="search" />
-        <input
-          className="bg-transparent ml-2 placeholder-gray-400 w-full"
-          placeholder="Search"
-        ></input>
-      </Search>
+      <Popover triggerAction="click" content={<div>hello popover</div>} full>
+        <Search className="p-2">
+          <Icon icon="search" />
+          <input
+            className="bg-transparent ml-2 placeholder-gray-400 w-full"
+            placeholder="Search"
+          ></input>
+        </Search>
+      </Popover>
       <List draggable={true} onMove={onMove}>
         {components.map((d, index) => (
           <ListItem key={d.id}>


### PR DESCRIPTION
# Popover

Add basic popover component. 

## Introduction

There are three ways to trigger popover: `click`, `hover` and `focus` and it can be placed on the `top/bottom/right/left` of the target element.

## Usage

```js
import { Popover } from 'components';

function Demo() {
  return (
    <Popover triggerAction="hover" content={<div>hello popover</div>}>
      <input />
    </Popover>
  )
}
```

## Notes

There are two main parts of popover: `trigger` and `portal`. Trigger is the part which react to user's input, so we should extend its props to handle supported events and measure its dimensions to place the popup. And portal is where we create the actual popup, so we should create and mount a container and pass the child to it.